### PR TITLE
Improved config management

### DIFF
--- a/grascii/config.py
+++ b/grascii/config.py
@@ -10,6 +10,14 @@ from pathlib import Path, PurePath
 from shutil import copyfile
 import sys
 
+SUPPORTS_INTERACTIVE = False
+try:
+    import questionary
+    from questionary import Choice
+    SUPPORTS_INTERACTIVE = True
+except ImportError as e:
+    pass
+
 from grascii.appdirs import user_config_dir
 
 APP_NAME = "grascii"
@@ -21,7 +29,7 @@ description = "Manage Grascii configuration"
 def build_argparser(argparser: argparse.ArgumentParser) -> None: 
     """Configure an ArgumentParser parser to parse the config command-line
     options
-    
+
     :parse argparser: A fresh ArgumentParser to configure.
     """
 
@@ -34,10 +42,12 @@ def build_argparser(argparser: argparse.ArgumentParser) -> None:
             help="Print the path to the configuration file and exit.")
     argparser.add_argument("-f", "--force", action="store_true",
             help="Allow overwriting of an existing configuration file.")
+    argparser.add_argument("-i", "--interactive", action="store_true",
+            help="Run in interactive mode.")
 
 def config_exists() -> bool:
     """Check whether the user configuration file exists.
-    
+
     :returns: True if the configuration file exists.
     """
 
@@ -46,7 +56,7 @@ def config_exists() -> bool:
 def get_config_file_path() -> PurePath:
     """Get a path object representating the location of the configuration
     file.
-    
+
     :returns: A path object.
     """
 
@@ -71,6 +81,11 @@ def cli_config(args: argparse.Namespace) -> None:
     :param args: A namespace of parsed arguments.
     """
 
+    if args.interactive:
+        if not SUPPORTS_INTERACTIVE:
+            print("The interactive extra is not installed", file=sys.stderr)
+            return
+
     if args.where:
         if config_exists():
             print(get_config_file_path())
@@ -78,10 +93,16 @@ def cli_config(args: argparse.Namespace) -> None:
             print("Configuration file does not exist. Use --init to create one.", file=sys.stderr)
     elif args.init:
         if config_exists() and not args.force:
-            print("Configuration file already exists.", file=sys.stderr)
-            print("If you would like to overwrite it with the default", 
-                  "configuration, run again with --force.", file=sys.stderr)
-            return
+            if args.interactive:
+                print("Configuration file already exists.")
+                answer = questionary.confirm("Would you like to overwrite it?", default=False, auto_enter=False).ask()
+                if not answer:
+                    return
+            else:
+                print("Configuration file already exists.", file=sys.stderr)
+                print("If you would like to overwrite it with the default",
+                      "configuration, run again with --force or --interactive.", file=sys.stderr)
+                return
         create_config()
         print("Configuration file created at", get_config_file_path())
     elif args.delete:
@@ -89,9 +110,14 @@ def cli_config(args: argparse.Namespace) -> None:
             print("Configuration file does not exist.", file=sys.stderr)
             return
         if not args.force:
-            print("Are you sure you want to delete the configuration file?",
-                  "If so, run with --force.", file=sys.stderr)
-            return
+            if args.interactive:
+                answer = questionary.confirm("Are you sure you want to delete the configuration file?", default=False, auto_enter=False).ask()
+                if not answer:
+                    return
+            else:
+                print("Are you sure you want to delete the configuration file?",
+                      "If so, run with --force or --interactive.", file=sys.stderr)
+                return
         delete_config()
         print("Removed", get_config_file_path())
 

--- a/grascii/config.py
+++ b/grascii/config.py
@@ -42,6 +42,8 @@ def build_argparser(argparser: argparse.ArgumentParser) -> None:
             help="Delete an existing configuration file.")
     group.add_argument("-w", "--where", action="store_true",
             help="Print the path to the configuration file and exit.")
+    group.add_argument("-e", "--edit", action="store_true",
+            help="Edit config options.")
     argparser.add_argument("-f", "--force", action="store_true",
             help="Allow overwriting of an existing configuration file.")
     argparser.add_argument("-i", "--interactive", action="store_true",
@@ -194,6 +196,9 @@ def cli_config(args: argparse.Namespace) -> None:
         if args.interactive:
             interactive_edit_config()
         print("Configuration file created at", get_config_file_path())
+    elif args.edit:
+        if args.interactive:
+            interactive_edit_config()
     elif args.delete:
         if not config_exists():
             print("Configuration file does not exist.", file=sys.stderr)

--- a/grascii/defaults.py
+++ b/grascii/defaults.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from grascii.config import get_config_file_path
 
 _CONFIG = ConfigParser()
+# TODO: read as package resource
 _CONFIG.read_file(Path(__file__).with_name("defaults.conf").open())
 _CONFIG.read(get_config_file_path())
 


### PR DESCRIPTION
The goal of this PR is to add interactivity to the `config` command and to allow for command line reading and editing of the config options. This will make editing the config more user-friendly and make it easier to change the config file format in the future if desired.

Todo:

- [x] Add `-i/--interactive` option to `grascii config` command
- [x] Present interactive confirmation for deletion of config file.
- [x] Present interactive confirmation for re-initializing the config file
- [ ] Add interactive initialization of new config file
- [ ] Add command to read config file `grascii config read`?
  - [ ] Allow reading by section or individual option
  - [ ] Allow reading a list of sections/options?
- [ ] Add command to edit config file `grascii config edit` or `write`
  - [ ] Allow editing by section or individual option
  - [ ] Allow editing a list of sections/options
  - [ ] Allow interactive editing of config file
- [ ] Refactor common code with `interactive.py`
- [ ] Update docs
- [ ] Details
  - [ ] Load `defaults.conf` as package resource
  - [ ] Update `questionary` version?